### PR TITLE
Add refresh token functionality to AuthController

### DIFF
--- a/src/modules/auth/controllers/auth.controller.ts
+++ b/src/modules/auth/controllers/auth.controller.ts
@@ -1,12 +1,21 @@
 import { Body, Controller, Post } from '@nestjs/common';
+import { RefreshTokenKeycloakService } from 'src/modules/keycloak/services/refresh-token.keycloak.service';
 import { AuthService } from '../services/auth.service';
 
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    private readonly refreshTokenKeycloakService: RefreshTokenKeycloakService,
+  ) {}
 
   @Post('login')
   async login(@Body() body) {
     return await this.authService.execute(body.email, body.password);
+  }
+
+  @Post('refresh-token')
+  async refreshToken(@Body() body) {
+    return await this.refreshTokenKeycloakService.execute(body.refresh_token);
   }
 }

--- a/src/modules/keycloak/keycloak.module.ts
+++ b/src/modules/keycloak/keycloak.module.ts
@@ -2,10 +2,19 @@ import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
 import { CreateUserKeycloakService } from './services/create-user.keycloak.service';
 import { LoginKeycloakService } from './services/login.keycloak.service';
+import { RefreshTokenKeycloakService } from './services/refresh-token.keycloak.service';
 
 @Module({
   imports: [HttpModule],
-  providers: [CreateUserKeycloakService, LoginKeycloakService],
-  exports: [CreateUserKeycloakService, LoginKeycloakService],
+  providers: [
+    CreateUserKeycloakService,
+    LoginKeycloakService,
+    RefreshTokenKeycloakService,
+  ],
+  exports: [
+    CreateUserKeycloakService,
+    LoginKeycloakService,
+    RefreshTokenKeycloakService,
+  ],
 })
 export class KeycloakModule {}

--- a/src/modules/keycloak/services/refresh-token.keycloak.service.ts
+++ b/src/modules/keycloak/services/refresh-token.keycloak.service.ts
@@ -1,0 +1,29 @@
+import { HttpService } from '@nestjs/axios';
+import { Injectable } from '@nestjs/common';
+import { firstValueFrom } from 'rxjs';
+
+@Injectable()
+export class RefreshTokenKeycloakService {
+  constructor(private http: HttpService) {}
+
+  async execute(refresh_token: string) {
+    const { data } = await firstValueFrom(
+      this.http.post(
+        `http://host.docker.internal:8080/realms/gym-focus/protocol/openid-connect/token`,
+        new URLSearchParams({
+          client_id: 'gym-focus-client',
+          client_secret: process.env.GYM_FOCUS_CLIENT_SECRET,
+          grant_type: 'refresh_token',
+          refresh_token,
+        }),
+      ),
+    );
+
+    return {
+      access_token: data.access_token,
+      refresh_token: data.refresh_token,
+      expires_in: data.expires_in,
+      refresh_expires_in: data.refresh_expires_in,
+    };
+  }
+}


### PR DESCRIPTION
This pull request adds a new endpoint to the AuthController for refreshing access tokens. The new `refresh-token` endpoint allows users to obtain a new access token by providing a refresh token. 